### PR TITLE
Feat Pyoidieコンソールでグラフ表示できるように

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-plotly.js": "^2.6.0",
         "react-split": "^2.0.14",
         "reflect-metadata": "^0.2.2",
+        "ts-pattern": "^5.8.0",
         "tsyringe": "^4.10.0",
         "uuid": "^11.1.0",
         "zod": "^4.0.14"
@@ -12283,6 +12284,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ts-pattern": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.8.0.tgz",
+      "integrity": "sha512-kIjN2qmWiHnhgr5DAkAafF9fwb0T5OhMVSWrm8XEdTFnX6+wfXwYOFjeF86UZ54vduqiR7BfqScFmXSzSaH8oA==",
+      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-plotly.js": "^2.6.0",
     "react-split": "^2.0.14",
     "reflect-metadata": "^0.2.2",
+    "ts-pattern": "^5.8.0",
     "tsyringe": "^4.10.0",
     "uuid": "^11.1.0",
     "zod": "^4.0.14"

--- a/src/app/(pages)/projects/[projectId]/edit/page.tsx
+++ b/src/app/(pages)/projects/[projectId]/edit/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box } from '@mui/material';
+import { Box, Card, CardContent, CardHeader, Divider } from '@mui/material';
 
 import { ProjectAssets } from '@/components/project';
 import {
@@ -8,7 +8,10 @@ import {
   Editor,
   SaveProjectButton,
 } from '@/features/editProject/components';
-import { PyodideConsole } from '@/features/inspectProject/components';
+import {
+  ClearLogButton,
+  PyodideConsole,
+} from '@/features/inspectProject/components';
 import { RunProjectButton } from '@/features/runProject/components';
 
 type PageParams = {
@@ -72,7 +75,33 @@ export default async function ProjectEditPage(props: {
             minHeight: 0,
           }}
         >
-          <PyodideConsole />
+          <Card
+            variant="outlined"
+            sx={{
+              height: '100%',
+              width: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+            }}
+          >
+            <CardHeader
+              title="実行ログ"
+              sx={{ pb: 1 }}
+              action={<ClearLogButton />}
+            />
+            <Divider />
+            <CardContent
+              sx={{
+                flex: 1,
+                overflowY: 'auto',
+                px: 2,
+                py: 1,
+              }}
+            >
+              <PyodideConsole />
+            </CardContent>
+          </Card>
         </div>
         <div
           style={{

--- a/src/components/PlotlyGraph.tsx
+++ b/src/components/PlotlyGraph.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import React from 'react';
+
+import Plot from 'react-plotly.js';
+
+import { PlotlyFigure } from '@/lib/plotly/types';
+
+type Props = {
+  figure: PlotlyFigure;
+};
+
+export function PlotlyGraph({ figure }: Props) {
+  return (
+    <Plot
+      data={figure.data}
+      layout={figure.layout}
+      style={{ width: '100%', height: '400px' }}
+      useResizeHandler
+    />
+  );
+}

--- a/src/components/PlotlyGraph.tsx
+++ b/src/components/PlotlyGraph.tsx
@@ -14,9 +14,12 @@ export function PlotlyGraph({ figure }: Props) {
   return (
     <Plot
       data={figure.data}
-      layout={figure.layout}
-      style={{ width: '100%', height: '400px' }}
-      useResizeHandler
+      layout={{
+        ...figure.layout,
+        margin: { t: 30, r: 5, b: 0, l: 5 },
+        autosize: true,
+      }}
+      style={{ height: '400px' }}
     />
   );
 }

--- a/src/features/inspectProject/components/ClearLogButton.tsx
+++ b/src/features/inspectProject/components/ClearLogButton.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React from 'react';
+
+import { Delete } from '@mui/icons-material';
+import { Box, IconButton, Tooltip } from '@mui/material';
+
+import { usePyodide } from '@/lib/pyodide';
+
+export function ClearLogButton() {
+  const { logService } = usePyodide();
+  return (
+    <Box>
+      <Tooltip title="ログをクリア">
+        <IconButton onClick={() => logService?.clear()}>
+          <Delete />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}

--- a/src/features/inspectProject/components/GraphEntryItem.tsx
+++ b/src/features/inspectProject/components/GraphEntryItem.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+
+import { Box, ListItem, Typography } from '@mui/material';
+
+import { PlotlyGraph } from '@/components/PlotlyGraph';
+import { Entry } from '@/lib/pyodide/types';
+
+type Props = {
+  entry: Entry;
+};
+
+export function GraphEntryItem({ entry }: Props) {
+  if (entry.content.type !== 'graph') {
+    return null;
+  }
+  const payload = entry.content.payload;
+
+  return (
+    <ListItem
+      alignItems="flex-start"
+      sx={{
+        flexDirection: 'column',
+        borderRadius: 1,
+        py: 0.5,
+        width: '100%',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
+        <Typography
+          component="span"
+          variant="body2"
+          sx={{ color: '#999', mr: 1 }}
+        >
+          [{entry.timestamp.toLocaleTimeString()}]
+        </Typography>
+      </Box>
+      <Box sx={{ width: '100%', mt: 1 }}>
+        <PlotlyGraph figure={payload} />
+      </Box>
+    </ListItem>
+  );
+}

--- a/src/features/inspectProject/components/GraphEntryItem.tsx
+++ b/src/features/inspectProject/components/GraphEntryItem.tsx
@@ -36,7 +36,7 @@ export function GraphEntryItem({ entry }: Props) {
           [{entry.timestamp.toLocaleTimeString()}]
         </Typography>
       </Box>
-      <Box sx={{ width: '100%', mt: 1 }}>
+      <Box sx={{ width: '100%', mt: 1, overflowX: 'auto' }}>
         <PlotlyGraph figure={payload} />
       </Box>
     </ListItem>

--- a/src/features/inspectProject/components/LogEntryItem.tsx
+++ b/src/features/inspectProject/components/LogEntryItem.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React from 'react';
+
+import { ListItem, ListItemText, Typography } from '@mui/material';
+
+import { Entry, LogType } from '@/lib/pyodide/types';
+
+type Props = {
+  entry: Entry;
+};
+
+export function LogEntryItem({ entry }: Props) {
+  if (entry.content.type !== 'log') {
+    return null;
+  }
+  const log = entry.content.payload;
+
+  return (
+    <ListItem
+      alignItems="flex-start"
+      sx={{
+        color: log.type === LogType.Error ? '#b00020' : 'inherit',
+        bgcolor:
+          log.type === LogType.Error ? 'rgba(255,0,0,0.05)' : 'transparent',
+        borderRadius: 1,
+        py: 0.5,
+        width: '100%',
+      }}
+    >
+      <ListItemText
+        primary={
+          <>
+            <Typography
+              component="span"
+              variant="body2"
+              sx={{ color: '#999', mr: 1 }}
+            >
+              [{entry.timestamp.toLocaleTimeString()}]
+            </Typography>
+            <Typography
+              component="span"
+              variant="body2"
+              sx={{
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+              }}
+            >
+              {log.message}
+            </Typography>
+          </>
+        }
+      />
+    </ListItem>
+  );
+}

--- a/src/features/inspectProject/components/index.ts
+++ b/src/features/inspectProject/components/index.ts
@@ -1,1 +1,2 @@
+export * from "./ClearLogButton";
 export * from './PyodideConsole';

--- a/src/lib/blockly/workspace/blocks/chart/plot.ts
+++ b/src/lib/blockly/workspace/blocks/chart/plot.ts
@@ -1,57 +1,57 @@
-import * as Blockly from "blockly/core";
-import { pythonGenerator, Order } from "blockly/python";
+import * as Blockly from 'blockly/core';
+import { pythonGenerator, Order } from 'blockly/python';
 
-export const CHART_PLOT_BLOCK_KEY = "chart_plot";
+export const CHART_PLOT_BLOCK_KEY = 'chart_plot';
 
 Blockly.Blocks[CHART_PLOT_BLOCK_KEY] = {
   init: function () {
-    this.appendValueInput("DF").setCheck("DataFrame").appendField("グラフ描画");
+    this.appendValueInput('DF').setCheck('DataFrame').appendField('グラフ描画');
     this.appendDummyInput()
-      .appendField("タイトル")
-      .appendField(new Blockly.FieldTextInput("グラフ"), "TITLE")
-      .appendField("x列")
-      .appendField(new Blockly.FieldTextInput("x"), "X_COLUMN")
-      .appendField("y列")
-      .appendField(new Blockly.FieldTextInput("y"), "Y_COLUMN")
-      .appendField("種類")
+      .appendField('タイトル')
+      .appendField(new Blockly.FieldTextInput('グラフ'), 'TITLE')
+      .appendField('x列')
+      .appendField(new Blockly.FieldTextInput('x'), 'X_COLUMN')
+      .appendField('y列')
+      .appendField(new Blockly.FieldTextInput('y'), 'Y_COLUMN')
+      .appendField('種類')
       .appendField(
         new Blockly.FieldDropdown([
-          ["散布図", "scatter"],
-          ["折れ線", "line"],
-          ["棒グラフ", "bar"],
-          ["ヒストグラム", "histogram"],
-          ["箱ひげ図", "box"],
+          ['散布図', 'scatter'],
+          ['折れ線', 'line'],
+          ['棒グラフ', 'bar'],
+          ['ヒストグラム', 'histogram'],
+          ['箱ひげ図', 'box'],
         ]),
-        "CHART_TYPE"
+        'CHART_TYPE',
       );
     this.setPreviousStatement(true);
     this.setNextStatement(true);
     this.setColour(260);
-    this.setTooltip("指定された列でグラフを描画します");
+    this.setTooltip('指定された列でグラフを描画します');
   },
 };
 
 pythonGenerator.forBlock[CHART_PLOT_BLOCK_KEY] = (block, generator) => {
-  const title = block.getFieldValue("TITLE");
-  const xCol = block.getFieldValue("X_COLUMN");
-  const yCol = block.getFieldValue("Y_COLUMN");
-  const chartType = block.getFieldValue("CHART_TYPE");
-  const dfCode = generator.valueToCode(block, "DF", Order.NONE) || "df";
+  const title = block.getFieldValue('TITLE');
+  const xCol = block.getFieldValue('X_COLUMN');
+  const yCol = block.getFieldValue('Y_COLUMN');
+  const chartType = block.getFieldValue('CHART_TYPE');
+  const dfCode = generator.valueToCode(block, 'DF', Order.NONE) || 'df';
 
-  (generator as any).definitions_["import_plotly"] =
-    "import plotly.express as px";
-  (generator as any).definitions_["import_json"] = "import json";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (generator as any).definitions_['import_plotly'] =
+    'import plotly.express as px';
 
   let plotCode;
   // ヒストグラムの場合はy軸を使わない
-  if (chartType === "histogram") {
-    plotCode = `px.histogram(${dfCode}, x="${xCol}")`;
+  if (chartType === 'histogram') {
+    plotCode = `px.histogram(${dfCode}, x="${xCol}", title="${title}")`;
   } else {
-    plotCode = `px.${chartType}(${dfCode}, x="${xCol}", y="${yCol}")`;
+    plotCode = `px.${chartType}(${dfCode}, x="${xCol}", y="${yCol}", title="${title}")`;
   }
 
   return `
 fig = ${plotCode}
-__show_plot_json("${title}", fig.to_json())
-  `;
+print(fig.to_json())\n
+`;
 };

--- a/src/lib/blockly/workspace/blocks/chart/show_table.ts
+++ b/src/lib/blockly/workspace/blocks/chart/show_table.ts
@@ -20,7 +20,20 @@ pythonGenerator.forBlock[CHART_SHOW_TABLE_BLOCK_KEY] = (block, generator) => {
   const title = block.getFieldValue("TITLE");
   const dfCode = generator.valueToCode(block, "DF", Order.NONE) || "df";
 
-  (generator as any).definitions_["import_json"] = "import json";
+  (generator as any).definitions_["import_plotly_go"] =
+    "import plotly.graph_objects as go";
 
-  return `__show_table_json("${title}", ${dfCode}.to_json(orient='split'))`;
+  const code = `
+fig = go.Figure(data=[go.Table(
+  header=dict(values=list(${dfCode}.columns),
+              fill_color='paleturquoise',
+              align='left'),
+  cells=dict(values=[${dfCode}[col] for col in ${dfCode}.columns],
+             fill_color='lavender',
+             align='left'))
+])
+fig.update_layout(title='${title}')
+print(fig.to_json())
+`;
+  return code;
 };

--- a/src/lib/blockly/workspace/blocks/chart/show_table.ts
+++ b/src/lib/blockly/workspace/blocks/chart/show_table.ts
@@ -1,38 +1,51 @@
-import * as Blockly from "blockly/core";
-import { pythonGenerator, Order } from "blockly/python";
+import * as Blockly from 'blockly/core';
+import { pythonGenerator, Order } from 'blockly/python';
 
-export const CHART_SHOW_TABLE_BLOCK_KEY = "chart_show_table";
+export const CHART_SHOW_TABLE_BLOCK_KEY = 'chart_show_table';
+
+const COLUMN_SIZE = 200;
 
 Blockly.Blocks[CHART_SHOW_TABLE_BLOCK_KEY] = {
   init: function () {
-    this.appendValueInput("DF").setCheck("DataFrame").appendField("表表示");
+    this.appendValueInput('DF').setCheck('DataFrame').appendField('表表示');
     this.appendDummyInput()
-      .appendField("タイトル")
-      .appendField(new Blockly.FieldTextInput("データ表"), "TITLE");
+      .appendField('タイトル')
+      .appendField(new Blockly.FieldTextInput('データ表'), 'TITLE');
     this.setPreviousStatement(true);
     this.setNextStatement(true);
     this.setColour(260);
-    this.setTooltip("DataFrameを表として表示します");
+    this.setTooltip('DataFrameを表として表示します');
   },
 };
 
 pythonGenerator.forBlock[CHART_SHOW_TABLE_BLOCK_KEY] = (block, generator) => {
-  const title = block.getFieldValue("TITLE");
-  const dfCode = generator.valueToCode(block, "DF", Order.NONE) || "df";
+  const title = block.getFieldValue('TITLE');
+  const dfCode = generator.valueToCode(block, 'DF', Order.NONE) || 'df';
 
-  (generator as any).definitions_["import_plotly_go"] =
-    "import plotly.graph_objects as go";
+  (generator as any).definitions_['import_plotly_go'] =
+    'import plotly.graph_objects as go';
 
   const code = `
-fig = go.Figure(data=[go.Table(
-  header=dict(values=list(${dfCode}.columns),
-              fill_color='paleturquoise',
-              align='left'),
-  cells=dict(values=[${dfCode}[col] for col in ${dfCode}.columns],
-             fill_color='lavender',
-             align='left'))
-])
-fig.update_layout(title='${title}')
+fig = go.Figure(
+  data=[go.Table(
+    columnwidth=[${COLUMN_SIZE}] * len(${dfCode}.columns),
+    header=dict(
+      values=list(${dfCode}.columns),
+      fill_color='paleturquoise',
+      align='left'
+    ),
+    cells=dict(
+      values=[${dfCode}[col] for col in ${dfCode}.columns],
+      fill_color='lavender',
+      align='left'
+    )
+  )],
+  layout=dict(
+    title='${title}',
+    autosize=False,
+    width=${COLUMN_SIZE} * len(df.columns) + 100,
+  )
+)
 print(fig.to_json())
 `;
   return code;

--- a/src/lib/plotly/types.ts
+++ b/src/lib/plotly/types.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+import { JsonFromString } from '@/lib/zod/utils';
+
+const BasePlotlyFigureSchema = z.object({
+  data: z.array(z.any()),
+  layout: z.record(z.string(), z.any()),
+});
+
+export const PlotlyFigureSchema = JsonFromString.pipe(BasePlotlyFigureSchema);
+
+export type PlotlyFigure = z.infer<typeof BasePlotlyFigureSchema>;

--- a/src/lib/pyodide/services/index.ts
+++ b/src/lib/pyodide/services/index.ts
@@ -1,1 +1,2 @@
 export * from './fileService';
+export * from "./logService"

--- a/src/lib/pyodide/services/logService.ts
+++ b/src/lib/pyodide/services/logService.ts
@@ -1,0 +1,42 @@
+import { Entry, LogType } from '../types';
+import { createEntry } from '../utils';
+
+type LogServiceEvent = 'change';
+
+type Listener = (entries: Entry[]) => void;
+
+export class LogService {
+  private entries: Entry[] = [];
+  private listeners: Record<LogServiceEvent, Set<Listener>> = {
+    change: new Set(),
+  };
+
+  constructor() {}
+
+  subscribe(event: LogServiceEvent, listener: Listener) {
+    this.listeners[event].add(listener);
+    return () => this.listeners[event].delete(listener); // unsubscribe
+  }
+
+  private emit(event: LogServiceEvent) {
+    this.listeners[event].forEach((l) => l(this.entries));
+  }
+
+  append(message: string, type: LogType) {
+    const entry = createEntry(message, type);
+    const maxLines = Number.parseInt(process.env.NEXT_PUBLIC_MAX_LOG_LINES!);
+    const trimmed =
+      this.entries.length >= maxLines ? this.entries.slice(1) : this.entries;
+    this.entries = [...trimmed, entry];
+    this.emit('change');
+  }
+
+  clear() {
+    this.entries = [];
+    this.emit('change');
+  }
+
+  getEntries() {
+    return this.entries;
+  }
+}

--- a/src/lib/pyodide/types.ts
+++ b/src/lib/pyodide/types.ts
@@ -1,0 +1,20 @@
+import { PlotlyFigure } from '@/lib/plotly/types';
+
+export enum LogType {
+  None,
+  Out,
+  Error,
+}
+
+export type LogMessage = {
+  type: LogType;
+  message: string;
+};
+
+export type Entry = {
+  id: string;
+  timestamp: Date;
+  content:
+    | { type: 'log'; payload: LogMessage }
+    | { type: 'graph'; payload: PlotlyFigure };
+};

--- a/src/lib/pyodide/utils.ts
+++ b/src/lib/pyodide/utils.ts
@@ -1,0 +1,61 @@
+import { createId } from '@paralleldrive/cuid2';
+import { match, P } from 'ts-pattern';
+
+import { PlotlyFigureSchema } from '@/lib/plotly/types';
+
+import { Entry, LogType } from './types';
+
+export function createEntry(message: string, type: LogType): Entry {
+  const trimmedMessage = message.trim();
+  const id = createId();
+  const timestamp = new Date();
+
+  return match([type, trimmedMessage])
+    .returnType<Entry>()
+    .with(
+      [LogType.Out, P.when((msg) => PlotlyFigureSchema.safeParse(msg).success)],
+      ([, msg]) => ({
+        id,
+        timestamp,
+        content: {
+          type: 'graph',
+          payload: PlotlyFigureSchema.parse(msg),
+        },
+      }),
+    )
+    .with([LogType.Out, P.string], ([, msg]) => ({
+      id,
+      timestamp,
+      content: {
+        type: 'log',
+        payload: {
+          type: LogType.Out,
+          message: msg,
+        },
+      },
+    }))
+    .with([LogType.Error, P.string], ([, msg]) => {
+      return {
+        id,
+        timestamp,
+        content: {
+          type: 'log',
+          payload: {
+            type: LogType.Error,
+            message: msg,
+          },
+        },
+      };
+    })
+    .otherwise(([, msg]) => ({
+      id,
+      timestamp,
+      content: {
+        type: 'log',
+        payload: {
+          type: LogType.None,
+          message: msg,
+        },
+      },
+    }));
+}

--- a/src/lib/zod/utils.ts
+++ b/src/lib/zod/utils.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * A Zod schema that preprocesses a string by attempting to parse it as JSON.
+ * If parsing fails, it returns a special `z.NEVER` type to invalidate the schema.
+ */
+export const JsonFromString = z.preprocess(
+  (val) => {
+    if (typeof val !== 'string' || val.trim() === '') {
+      return val; // Pass through non-strings or empty strings
+    }
+    try {
+      return JSON.parse(val);
+    } catch {
+      return z.NEVER; // Invalidate schema if JSON parsing fails
+    }
+  },
+  z.any()
+);


### PR DESCRIPTION
## 概要
- PyodideConsole をリファクタリング
- コンソールで表示されるアイテムをそれぞれ切り出し、ログタイプをもとに出しわけるように変更
- pyodideでの標準出力を経由してplotlyのグラフjsonを受け取った場合にグラフコンポーネントに切り替えるように
